### PR TITLE
Add wrapper for lager_msg

### DIFF
--- a/include/lager.hrl
+++ b/include/lager.hrl
@@ -76,15 +76,15 @@
          {error_unsafe, error}, {critical_unsafe, critical}, {alert_unsafe, alert}, 
          {emergency_unsafe, emergency}]).
 
-%-define(DEBUG, 128).
-%-define(INFO, 64).
-%-define(NOTICE, 32).
-%-define(WARNING, 16).
-%-define(ERROR, 8).
-%-define(CRITICAL, 4).
-%-define(ALERT, 2).
-%-define(EMERGENCY, 1).
-%-define(LOG_NONE, 0).
+-define(DEBUG, 128).
+-define(INFO, 64).
+-define(NOTICE, 32).
+-define(WARNING, 16).
+-define(ERROR, 8).
+-define(CRITICAL, 4).
+-define(ALERT, 2).
+-define(EMERGENCY, 1).
+-define(LOG_NONE, 0).
 
 -define(LEVEL2NUM(Level),
         case Level of

--- a/src/lager.erl
+++ b/src/lager.erl
@@ -86,7 +86,7 @@
 %% Record and Type Definitions
 %%-------------------------------------------------------------------
 
--type log_level() :: none | debug | info | notice | warning | error | critical | alert | emergency.
+-type log_level() :: none | logger:level().
 
 %%-------------------------------------------------------------------
 %% API Function Definitions

--- a/src/lager_msg.erl
+++ b/src/lager_msg.erl
@@ -1,0 +1,81 @@
+-module(lager_msg).
+
+-include("lager.hrl").
+
+-export([new/4, new/5]).
+-export([message/1]).
+-export([timestamp/1]).
+-export([datetime/1]).
+-export([severity/1]).
+-export([severity_as_int/1]).
+-export([metadata/1]).
+-export([destinations/1]).
+
+-opaque lager_msg() :: logger:log_event().
+-export_type([lager_msg/0]).
+
+-define(MEGA, 1000000).
+
+%% create with provided timestamp, handy for testing mostly
+-spec new(list(), erlang:timestamp(), lager:log_level(), [tuple()], list()) -> lager_msg().
+new(_Msg, _Timestamp, none, _Metadata, _Destinations) ->
+    error(nosup);
+new(Msg, {MSec, Sec, USec}, Level, Metadata, _Destinations) ->
+    Time = MSec + (Sec + (USec * ?MEGA) * ?MEGA),
+    Meta = maps:put(time, Time, maps:from_list(Metadata)),
+    #{level => Level, msg => {string, Msg}, meta => Meta}.
+
+-spec new(list(), lager:log_level(), [tuple()], list()) -> lager_msg().
+new(_Msg, _Level, _Metadata, _Destinations) ->
+    error(nosup);
+new(Msg, Level, Metadata, _Destinations) ->
+    Time = logger:timestamp(),
+    Meta = maps:put(time, Time, maps:from_list(Metadata)),
+    #{level => Level, msg => {string, Msg}, meta => Meta}.
+
+-spec message(lager_msg()) -> list().
+message(#{msg := Msg, meta := Meta}) ->
+    unicode:characters_to_list(normalize_msg(Msg, Meta)).
+
+normalize_msg({report, Report}, #{report_cb := Cb}) when is_function(Cb, 1) ->
+    Cb(Report);
+normalize_msg({report, Report}, #{report_cb := Cb}) when is_function(Cb, 2) ->
+    Cb(Report, #{});
+normalize_msg({report, Report}, _Meta) ->
+    [io_lib:fwrite("~w=~w", [Key, Value])
+     || {Key, Value} <- maps:to_list(Report)];
+normalize_msg({string, String}, _Meta) ->
+    String;
+normalize_msg({Format, Data}, _Meta)
+  when is_atom(Format); is_list(Format); is_binary(Format) ->
+    io_lib:fwrite(Format, Data).
+
+-spec timestamp(lager_msg()) -> erlang:timestamp().
+timestamp(#{meta := #{time := Timestamp}}) ->
+    MicroSecs = Timestamp rem ?MEGA,
+    Secs = Timestamp div ?MEGA,
+    MegaSecs = Secs div ?MEGA,
+    {MegaSecs, Secs rem ?MEGA, MicroSecs}.
+
+-spec datetime(lager_msg()) -> {string(), string()}.
+datetime(#{meta := #{time := Timestamp}}) ->
+    {{Y, Mo, D}, {H, Mi, S}} = calendar:system_time_to_universal_time(Timestamp, millisecond),
+    DateStr = io_lib:format("~4..0B-~2..0B-~2..0B", [Y, Mo, D]),
+    TimeStr = io_lib:format("~2..0B:~2..0B:~2..0B", [H, Mi, S]),
+    {DateStr, TimeStr}.
+
+-spec severity(lager_msg()) -> lager:log_level().
+severity(#{level := Level}) ->
+    Level.
+
+-spec severity_as_int(lager_msg()) -> lager:log_level_number().
+severity_as_int(#{level := Level}) ->
+    ?LEVEL2NUM(Level).
+
+-spec metadata(lager_msg()) -> [tuple()].
+metadata(#{meta := Meta}) ->
+    maps:to_list(Meta).
+
+-spec destinations(lager_msg()) -> list().
+destinations(_Msg) ->
+    error(nosup).


### PR DESCRIPTION
This is first step for supporting Lager backends as logger backends.

Fortunately for us the `lager_msg:lager_msg()` was an opaque type, so we can just pass around the `logger:log_event()` and compute required values only when needed.